### PR TITLE
fix(stryker) Display stryker errors on the console instead of hiding them

### DIFF
--- a/tasks/stryker.js
+++ b/tasks/stryker.js
@@ -30,8 +30,8 @@ module.exports = function (grunt) {
     var stryker = new Stryker(options);
     stryker.runMutationTest().then(function () {
       done();
-    }, function () {
-      grunt.fail.fatal("Stryker was unable to run the mutation test");
+    }, function (error) {
+        grunt.fail.fatal("Stryker was unable to run the mutation test. " + error);
     });
   });
 


### PR DESCRIPTION
Currently, if stryker throws an error it is not shown in the console because all errors are caught and a generic message is shown. This commit changes this behaviour by appending the error message to the generic message. This makes debugging stryker related errors way easier.